### PR TITLE
feat: update deprecated ongenerate hook to generateBundle

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,14 +56,17 @@ module.exports = (options) => {
         },
 
         // Spit out stats during bundle generation
-        ongenerate : (details) => {
+        generateBundle : (_, bundles) => {
+            const [ file ] = Object.keys(bundles);
+            const bundle = bundles[file];
+            
             let total = 0;
             const data = {};
             const totals = [];
-            const ids = Object.keys(details.bundle.modules);
+            const ids = Object.keys(bundle.modules);
 
             ids.forEach((id) => {
-                const module = details.bundle.modules[id];
+                const module = bundle.modules[id];
                 let parsed;
 
                 // Handle rollup-injected helpers


### PR DESCRIPTION
:wave: I was trying out this package when I noticed the deprecation warning for `ongenerate`.

This seems to fix it AFAIC

`bundles` could represent multiple output files, but since the `modules` would be the same I just grab the first file. 

Let me know if you think this assumption is incorrect.

I didn't mix it into this PR, but it also be worth running `npm audit fix`, there were some warnings. 

fixes #13 