### PR TITLE
chore: update rollup dep to v2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
         "@tivac",
     ],
 
-    parserOptions: {
+    parserOptions : {
         ecmaVersion : 2017,
     },
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = (options) => {
         // Spit out stats during bundle generation
         generateBundle : (_, bundles) => {
             Object.values(bundles).forEach((bundle, idx) => {
-                if (!bundle.modules) {
+                if(!bundle.modules) {
                     return;
                 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -991,12 +991,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/estree": {
-      "version": "0.0.44",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
-      "integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
-      "dev": true
-    },
     "@types/graceful-fs": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
@@ -6372,14 +6366,12 @@
       }
     },
     "rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.21.0.tgz",
+      "integrity": "sha512-BEGgy+wSzux7Ycq58pRiWEOBZaXRXTuvzl1gsm7gqmsAHxkWf9nyA5V2LN9fGSHhhDQd0/C13iRzSh4bbIpWZQ==",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.1.2"
       }
     },
     "rsvp": {

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "conventional-changelog-cli": "^2.0.28",
     "eslint": "^7.1.0",
     "jest": "^26.0.1",
-    "rollup": "^1.27.8"
+    "rollup": "^2.21.0"
   },
   "dependencies": {
     "filesize": "^6.0.1",
     "module-details-from-path": "^1.0.3"
   },
   "peerDependencies": {
-    "rollup": "^1.0.0"
+    "rollup": "^2.0.0"
   }
 }


### PR DESCRIPTION
Related issue: https://github.com/tivac/rollup-plugin-sizes/issues/44
Also fixed couple of lint warnings.