### PR TITLE
fix: don't crash when module doesn't map to an input

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = (options) => {
                     return;
                 }
 
-                const base = bases[idx];
+                const base = bases[idx] || "";
 
                 let total = 0;
                 const data = {};
@@ -121,7 +121,7 @@ module.exports = (options) => {
                 });
 
                 report({
-                    input : input[idx],
+                    input : input[idx] || bundle.fileName,
                     data,
                     totals,
                     total,


### PR DESCRIPTION
In our build we're using a manualChunks function to split off modules into distinct chunks by purpose. This resulted in a crash in this plugin because those chunks do not receive entries in the config, and thus `base` came out as undefined, which `path.resolve` rejects.

This change causes the plugin to use the bundle filename if no input name exists, preventing a crash and correcting the output.