### PR TITLE
feat: add rollup@4 support

### DIFF
--- a/.changeset/long-geckos-perform.md
+++ b/.changeset/long-geckos-perform.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-sizes": patch
+---
+
+feat: add rollup@4 support

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "rollup": "^4.2.0"
       },
       "peerDependencies": {
-        "rollup": "^4.2.0"
+        "rollup": "^2 || ^3 || ^4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "module-details-from-path": "^1.0.3"
   },
   "peerDependencies": {
-    "rollup": "^2 || ^3"
+    "rollup": "^2 || ^3 || ^4"
   }
 }


### PR DESCRIPTION
The build depends on rollup@4.2.0 as of d41acd7 and the CI jobs pass.
The version of the plugin has been confirmed to work with rollup by at least 2 people.

### Notes

The `package-lock.json` file was incorrectly updated by #176 which wrongly updated the rollup peerDependencies field from to from `^2 || ^3` to `^4.2.0`

Closes #174