### PR TITLE
Fix this plugin with `vite` dev server

### DIFF
--- a/.changeset/kind-pillows-smile.md
+++ b/.changeset/kind-pillows-smile.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-sizes": minor
+---
+
+Made this plugin compatible with `vite`

--- a/index.js
+++ b/index.js
@@ -57,6 +57,8 @@ module.exports = (options) => {
                 input = original;
             } else if(typeof original === "object") {
                 input = Object.values(original);
+            } else if(typeof original === "undefined") {
+                input = [];
             } else {
                 input = [ original ];
             }


### PR DESCRIPTION
Hey :)

First of all: Thanks for this great project. Has already proven useful to me :)

However when  I was trying to use this plugin as a `vite` plugin, building the assets worked fine, but starting the dev server failed with the following message:

```
error when starting dev server:
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Object.dirname (node:path:1346:5)
    at .../node_modules/rollup-plugin-sizes/index.js:68:48
    at Array.map (<anonymous>)
    at Object.options (.../node_modules/rollup-plugin-sizes/index.js:68:27)
    at PluginContainer.resolveRollupOptions (file://.../node_modules/vite/dist/node/chunks/dep-DG6Lorbi.js:48895:23)
    at createPluginContainer (file://.../node_modules/vite/dist/node/chunks/dep-DG6Lorbi.js:48799:19)
    at _createServer (file://.../node_modules/vite/dist/node/chunks/dep-DG6Lorbi.js:62752:27)
    at async CAC.<anonymous> (file://.../node_modules/vite/dist/node/cli.js:735:20)
```

It seems when the dev server is started, the plugin will receive an empty (`{}`) config. This then leads to the above error.

Handling this case explicitely solves the problem. The report is only printed when running `vite build`, but that is okay/preferable for my usecase.

I thought I would open a CR, so that other people using this plugin with `vite` don't run into the same problem :)